### PR TITLE
Bug/gradlew

### DIFF
--- a/complaint-orchestrator/Dockerfile
+++ b/complaint-orchestrator/Dockerfile
@@ -2,6 +2,7 @@ FROM eclipse-temurin:17-jdk AS builder
 WORKDIR /app
 COPY gradle/ gradle/
 COPY gradlew gradlew.bat settings.gradle build.gradle ./
+RUN chmod +x gradlew
 RUN ./gradlew dependencies --no-daemon
 COPY src/ src/
 RUN ./gradlew bootJar -x test --no-daemon

--- a/complaint-orchestrator/gradle/wrapper/gradle-wrapper.properties
+++ b/complaint-orchestrator/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,9 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
+retries=0
+retryBackOffMs=500
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/complaint-orchestrator/gradlew
+++ b/complaint-orchestrator/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/2d6327017519d23b96af35865dc997fcb544fb40/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/3d91ce3b8caaf77ad09f381f43615b715b53f72c/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/complaint-orchestrator/gradlew.bat
+++ b/complaint-orchestrator/gradlew.bat
@@ -23,8 +23,8 @@
 @rem
 @rem ##########################################################################
 
-@rem Set local scope for the variables with windows NT shell
-if "%OS%"=="Windows_NT" setlocal
+@rem Set local scope for the variables, and ensure extensions are enabled
+setlocal EnableExtensions
 
 set DIRNAME=%~dp0
 if "%DIRNAME%"=="" set DIRNAME=.
@@ -51,7 +51,7 @@ echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
-goto fail
+"%COMSPEC%" /c exit 1
 
 :findJavaFromJavaHome
 set JAVA_HOME=%JAVA_HOME:"=%
@@ -65,7 +65,7 @@ echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
 echo location of your Java installation. 1>&2
 
-goto fail
+"%COMSPEC%" /c exit 1
 
 :execute
 @rem Setup the command line
@@ -73,21 +73,10 @@ goto fail
 
 
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %*
+@rem endlocal doesn't take effect until after the line is parsed and variables are expanded
+@rem which allows us to clear the local environment before executing the java command
+endlocal & "%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -jar "%APP_HOME%\gradle\wrapper\gradle-wrapper.jar" %* & call :exitWithErrorLevel
 
-:end
-@rem End local scope for the variables with windows NT shell
-if %ERRORLEVEL% equ 0 goto mainEnd
-
-:fail
-rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
-rem the _cmd.exe /c_ return code!
-set EXIT_CODE=%ERRORLEVEL%
-if %EXIT_CODE% equ 0 set EXIT_CODE=1
-if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
-exit /b %EXIT_CODE%
-
-:mainEnd
-if "%OS%"=="Windows_NT" endlocal
-
-:omega
+:exitWithErrorLevel
+@rem Use "%COMSPEC%" /c exit to allow operators to work properly in scripts
+"%COMSPEC%" /c exit %ERRORLEVEL%


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #3 

## 📝 개요
- Windows 환경에서 git clone 후 docker-compose up --build 실행 시 gradlew 파일의 실행 권한이 없어 Spring 이미지 빌드가 실패하는 문제 수정

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [x] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- complaint-orchestrator/Dockerfile에 `RUN chmod +x gradlew` 추가
- Windows에서 git clone 시 gradlew 실행 권한이 사라지는 문제를 Dockerfile 레벨에서 해결


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [x] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.