### PR TITLE
[Feat] 파일 목록 조회 API 응답 개선 및 파일 용량 저장

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/domain/file/File.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/domain/file/File.java
@@ -26,7 +26,7 @@ public class File {
     private int rowCount;
 
     @Column
-    private int capacity;
+    private long capacity;
 
     @Column(name = "uploaded_at", nullable = false)
     private LocalDateTime uploadedAt;
@@ -55,5 +55,9 @@ public class File {
 
     public void updateRowCount(int rowCount) {
         this.rowCount = rowCount;
+    }
+
+    public void updateCapacity(long capacity) {
+        this.capacity = capacity;
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/FileListResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/FileListResponseDto.java
@@ -7,11 +7,4 @@ import java.util.List;
 public record FileListResponseDto(
         List<FileResponseDto> files
 ) {
-    public static FileListResponseDto from(List<File> files) {
-        return new FileListResponseDto(
-                files.stream()
-                        .map(FileResponseDto::from)
-                        .toList()
-        );
-    }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/FileResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/FileResponseDto.java
@@ -16,7 +16,7 @@ public record FileResponseDto(
         String name,
 
         @NotNull
-        int capacity,
+        long capacity,
 
         int complaintCount,
 

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/FileResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/FileResponseDto.java
@@ -1,6 +1,7 @@
 package edu.dongguk.complaint.orchestrator.dto.response;
 
 import edu.dongguk.complaint.orchestrator.domain.file.File;
+import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -20,15 +21,23 @@ public record FileResponseDto(
         int complaintCount,
 
         @NotNull
-        LocalDateTime uploadedAt
+        LocalDateTime uploadedAt,
+
+        @NotNull
+        FileStatus status,
+
+        @NotNull
+        String checkedDepartCount
 ) {
-    public static FileResponseDto from(File file) {
+    public static FileResponseDto from(File file, String checkedDepartCount) {
         return new FileResponseDto(
                 file.getId(),
                 file.getFileName(),
                 file.getCapacity(),
                 file.getRowCount(),
-                file.getUploadedAt()
+                file.getUploadedAt(),
+                file.getStatus(),
+                checkedDepartCount
         );
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
@@ -2,9 +2,14 @@ package edu.dongguk.complaint.orchestrator.repository;
 
 import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     List<Complaint> findAllByFileId(Long fileId);
+
+    @Query("SELECT COUNT(DISTINCT c.depart.id) FROM Complaint c WHERE c.file.id = :fileId AND c.isChecked = true")
+    long countCheckedDepartsByFileId(@Param("fileId") Long fileId);
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/DepartRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/DepartRepository.java
@@ -1,0 +1,7 @@
+package edu.dongguk.complaint.orchestrator.repository;
+
+import edu.dongguk.complaint.orchestrator.domain.Depart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DepartRepository extends JpaRepository<Depart, Long> {
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/FileUploadService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/FileUploadService.java
@@ -30,6 +30,7 @@ public class FileUploadService {
 
     public Long uploadFile(MultipartFile multipartFile) throws IOException {
         File file = new File(multipartFile.getOriginalFilename(), 0);
+        file.updateCapacity(multipartFile.getSize());
         fileRepository.save(file);
 
         List<ComplaintData> dataList = excelParser.parse(multipartFile);

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
@@ -1,18 +1,37 @@
 package edu.dongguk.complaint.orchestrator.service.query;
 
+import edu.dongguk.complaint.orchestrator.domain.file.File;
 import edu.dongguk.complaint.orchestrator.dto.response.FileListResponseDto;
+import edu.dongguk.complaint.orchestrator.dto.response.FileResponseDto;
+import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
+import edu.dongguk.complaint.orchestrator.repository.DepartRepository;
 import edu.dongguk.complaint.orchestrator.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class FileQueryService {
     private final FileRepository fileRepository;
+    private final ComplaintRepository complaintRepository;
+    private final DepartRepository departRepository;
 
     public FileListResponseDto getfiles() {
-        return FileListResponseDto.from(fileRepository.findAll());
+        List<File> files = fileRepository.findAll();
+        long totalDeparts = departRepository.count();
+
+        List<FileResponseDto> fileResponseDtoList = files.stream()
+                .map(file -> {
+                    long checkedDeparts = complaintRepository.countCheckedDepartsByFileId(file.getId());
+                    String checkedDepartCount = checkedDeparts + "/" + totalDeparts;
+                    return FileResponseDto.from(file, checkedDepartCount);
+                })
+                .toList();
+
+        return new FileListResponseDto(fileResponseDtoList);
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/sse/SseEmitterService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/sse/SseEmitterService.java
@@ -20,6 +20,8 @@ public class SseEmitterService {
         emitters.put(id, emitter);
         emitter.onCompletion(() -> emitters.remove(id));
         emitter.onTimeout(() -> emitters.remove(id));
+        emitter.onError(e -> emitters.remove(id));
+
         return emitter;
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #6

## 📝 개요
- 기존 파일 목록 조회 API 응답에 파일의 처리 상태, 부서별 확인 현황, 파일 용량 정보가 누락되어 있어 클라이언트에서 파일 진행 상태를 파악할 수 없었음

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- 파일 정보 GET API 응답에 `status` 필드 포함 (UPLOADING / PENDING / COMPLETED / ERROR)
- 파일 정보 GET API 응답에 `checkedDepartCount` 필드 포함 ({확인 완료 부서 수}/{전체 부서 수} 형태)
- `ComplaintRepository`에 부서별 확인 완료 수 조회 쿼리 추가
- `DepartRepository` 추가
- `FileQueryService`에 전체 부서 수 및 확인 완료 부서 수 계산 로직 구현
- `File` 엔티티 `capacity` 타입 `int` → `long` 변경
- 파일 업로드 시 용량이 바이트 단위로 long 타입에 저장되며 응답에 `capacity` 필드 포함


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.