### PR TITLE
Feat: 부서별 민원 목록 조회 API 구현

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -1,6 +1,7 @@
 package edu.dongguk.complaint.orchestrator.controller;
 
 import edu.dongguk.complaint.orchestrator.dto.response.ComplaintListResponseDto;
+import edu.dongguk.complaint.orchestrator.service.query.ComplaintQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -1,0 +1,21 @@
+package edu.dongguk.complaint.orchestrator.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/departs")
+@RequiredArgsConstructor
+public class DepartController {
+    private final ComplaintQueryService complaintQueryService;
+
+
+    @GetMapping("/{departId}")
+    public ResponseEntity<ComplaintListResponseDto> getComplaints(@PathVariable Long departId){
+        return ResponseEntity.ok(complaintQueryService.getComplaints(departId));
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -1,5 +1,6 @@
 package edu.dongguk.complaint.orchestrator.controller;
 
+import edu.dongguk.complaint.orchestrator.dto.response.ComplaintListResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/ComplaintListResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/ComplaintListResponseDto.java
@@ -1,0 +1,6 @@
+package edu.dongguk.complaint.orchestrator.dto.response;
+
+import java.util.List;
+
+public record ComplaintListResponseDto(List<ComplaintResponseDto> complaints) {
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/ComplaintResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/ComplaintResponseDto.java
@@ -1,0 +1,24 @@
+package edu.dongguk.complaint.orchestrator.dto.response;
+
+import edu.dongguk.complaint.orchestrator.domain.ProcessCodeType;
+import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
+import jakarta.validation.constraints.NotNull;
+
+public record ComplaintResponseDto(
+        @NotNull
+        String title,
+
+        @NotNull
+        String content,
+
+        @NotNull
+        ProcessCodeType code
+) {
+    public static ComplaintResponseDto from(Complaint complaint) {
+        return new ComplaintResponseDto(
+                complaint.getTitle(),
+                complaint.getContent(),
+                complaint.getProcessCodeType()
+        );
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     List<Complaint> findAllByFileId(Long fileId);
+    List<Complaint> findByDepartId(Long departId);
 
     @Query("SELECT COUNT(DISTINCT c.depart.id) FROM Complaint c WHERE c.file.id = :fileId AND c.isChecked = true")
     long countCheckedDepartsByFileId(@Param("fileId") Long fileId);

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/ComplaintQueryService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/ComplaintQueryService.java
@@ -1,0 +1,27 @@
+package edu.dongguk.complaint.orchestrator.service.query;
+
+
+import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
+import edu.dongguk.complaint.orchestrator.dto.response.ComplaintListResponseDto;
+import edu.dongguk.complaint.orchestrator.dto.response.ComplaintResponseDto;
+import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ComplaintQueryService {
+    private final ComplaintRepository complaintRepository;
+
+    public ComplaintListResponseDto getComplaints(Long departId){
+        List<ComplaintResponseDto> complaints = complaintRepository.findByDepartId(departId)
+                .stream()
+                .map(complaint -> ComplaintResponseDto.from(complaint))
+                .toList();
+        return new ComplaintListResponseDto(complaints);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #12

## 📝 개요
- 부서별 배부된 민원 목록을 조회하는 API 구현

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- DepartController: GET /api/v1/departs/{departId} 엔드포인트 추가
- ComplaintQueryService: 부서 ID로 민원 목록 조회 로직 구현
- ComplaintRepository: findByDepartId 메서드 추가
- ComplaintListResponseDto, ComplaintResponseDto 추가


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.