### PR TITLE
Feat/complaint list slicing

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -3,11 +3,10 @@ package edu.dongguk.complaint.orchestrator.controller;
 import edu.dongguk.complaint.orchestrator.dto.response.ComplaintListResponseDto;
 import edu.dongguk.complaint.orchestrator.service.query.ComplaintQueryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/departs")
@@ -17,7 +16,11 @@ public class DepartController {
 
 
     @GetMapping("/{departId}")
-    public ResponseEntity<ComplaintListResponseDto> getComplaints(@PathVariable Long departId){
-        return ResponseEntity.ok(complaintQueryService.getComplaints(departId));
+    public ResponseEntity<ComplaintListResponseDto> getComplaints(
+            @PathVariable Long departId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int  size){
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(complaintQueryService.getComplaints(departId,  pageable));
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/FileController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/FileController.java
@@ -49,6 +49,7 @@ public class FileController {
     ) {
         departCheckService.checkDeparts(fileId, requestDto);
         return ResponseEntity.ok().build();
+    }
     @GetMapping(value = "/{fileId}")
     public ResponseEntity<DepartListComplaintResponseDto> getFileResult(@PathVariable Long fileId) {
         return ResponseEntity.ok(fileQueryService.getFileResult(fileId));

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/ComplaintListResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/ComplaintListResponseDto.java
@@ -2,5 +2,5 @@ package edu.dongguk.complaint.orchestrator.dto.response;
 
 import java.util.List;
 
-public record ComplaintListResponseDto(List<ComplaintResponseDto> complaints) {
+public record ComplaintListResponseDto(List<ComplaintResponseDto> complaints, Boolean hasNext) {
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
@@ -2,6 +2,8 @@ package edu.dongguk.complaint.orchestrator.repository;
 
 import edu.dongguk.complaint.orchestrator.domain.Depart;
 import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,7 +13,7 @@ import java.util.List;
 
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     List<Complaint> findAllByFileId(Long fileId);
-    List<Complaint> findByDepartId(Long departId);
+    Slice<Complaint> findByDepartId(Long departId, Pageable pageable);
 
     @Query("SELECT COUNT(DISTINCT c.depart.id) FROM Complaint c WHERE c.file.id = :fileId AND c.isChecked = true")
     long countCheckedDepartsByFileId(@Param("fileId") Long fileId);

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/ComplaintQueryService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/ComplaintQueryService.java
@@ -7,6 +7,8 @@ import edu.dongguk.complaint.orchestrator.dto.response.ComplaintResponseDto;
 import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,11 +19,14 @@ import java.util.List;
 public class ComplaintQueryService {
     private final ComplaintRepository complaintRepository;
 
-    public ComplaintListResponseDto getComplaints(Long departId){
-        List<ComplaintResponseDto> complaints = complaintRepository.findByDepartId(departId)
+    public ComplaintListResponseDto getComplaints(Long departId, Pageable pageable) {
+
+        Slice<Complaint> slice = complaintRepository.findByDepartId(departId, pageable);
+
+        List<ComplaintResponseDto> complaints = slice
                 .stream()
                 .map(complaint -> ComplaintResponseDto.from(complaint))
                 .toList();
-        return new ComplaintListResponseDto(complaints);
+        return new ComplaintListResponseDto(complaints, slice.hasNext());
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #14

## 📝 개요
- 기존 DepartController의 getComplaints에 Slicing을 적용해서 한번에 모든 민원을 불러오지 않고 슬라이싱으로 불러오도록 구현
- FileController에 닫는 중괄호 하나 빠져있는거 수정

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- DapartController가 기존에는 모든 민원들을 List로 받아와서 전달했지만 이 경우 민원개수 많을 경우 한번에 다 로딩해와야 하는 문제점이 있다.
- Slicing을 적용해서 해결한다. default로 page size는 10으로 설정했고 front에서 api를 보낼때 파라미터로 page와 size를 보낸다.


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.