### PR TITLE
[fix] 개별 부서 확인 취소 기능으로 변경 #22

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -2,8 +2,6 @@ package edu.dongguk.complaint.orchestrator.controller;
 
 import edu.dongguk.complaint.orchestrator.dto.response.ComplaintListResponseDto;
 import edu.dongguk.complaint.orchestrator.service.query.ComplaintQueryService;
-import edu.dongguk.complaint.orchestrator.service.command.DepartCheckService;
-import edu.dongguk.complaint.orchestrator.dto.request.DepartListRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +13,6 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class DepartController {
     private final ComplaintQueryService complaintQueryService;
-    private final DepartCheckService departCheckService;
 
     @GetMapping("/{departId}")
     public ResponseEntity<ComplaintListResponseDto> getComplaints(

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -25,10 +25,4 @@ public class DepartController {
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(complaintQueryService.getComplaints(departId,  pageable));
     }
-
-    @PatchMapping("/{fileId}/departs/uncheck")
-    public ResponseEntity<Void> uncheckDeparts(@PathVariable Long fileId, @RequestBody DepartListRequestDto requestDto) {
-        departCheckService.uncheckDeparts(fileId, requestDto);
-        return ResponseEntity.ok().build();
-    }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -2,6 +2,8 @@ package edu.dongguk.complaint.orchestrator.controller;
 
 import edu.dongguk.complaint.orchestrator.dto.response.ComplaintListResponseDto;
 import edu.dongguk.complaint.orchestrator.service.query.ComplaintQueryService;
+import edu.dongguk.complaint.orchestrator.service.command.DepartCheckService;
+import edu.dongguk.complaint.orchestrator.dto.request.DepartListRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class DepartController {
     private final ComplaintQueryService complaintQueryService;
-
+    private final DepartCheckService departCheckService;
 
     @GetMapping("/{departId}")
     public ResponseEntity<ComplaintListResponseDto> getComplaints(
@@ -22,5 +24,11 @@ public class DepartController {
             @RequestParam(defaultValue = "10") int  size){
         Pageable pageable = PageRequest.of(page, size);
         return ResponseEntity.ok(complaintQueryService.getComplaints(departId,  pageable));
+    }
+
+    @PatchMapping("/{fileId}/departs/uncheck")
+    public ResponseEntity<Void> uncheckDeparts(@PathVariable Long fileId, @RequestBody DepartListRequestDto requestDto) {
+        departCheckService.uncheckDeparts(fileId, requestDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/FileController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/FileController.java
@@ -54,4 +54,13 @@ public class FileController {
     public ResponseEntity<DepartListComplaintResponseDto> getFileResult(@PathVariable Long fileId) {
         return ResponseEntity.ok(fileQueryService.getFileResult(fileId));
     }
+
+    @PatchMapping(value = "/{fileId}/departs/uncheck")
+    public ResponseEntity<Void> uncheckDeparts(
+            @PathVariable Long fileId,
+            @RequestBody DepartListRequestDto requestDto
+    ) {
+        departCheckService.uncheckDeparts(fileId, requestDto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/DepartListComplaintResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/DepartListComplaintResponseDto.java
@@ -6,6 +6,6 @@ public record DepartListComplaintResponseDto(
         List<DepartComplaintResponseDto> departs
 ) {
     public static DepartListComplaintResponseDto from(List<DepartComplaintResponseDto> departs) {
-        return new DepartListComplaintResponseDto(departs);
+        return new DepartListComplaintResponseDtodeparts();
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/DepartListComplaintResponseDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/response/DepartListComplaintResponseDto.java
@@ -6,6 +6,6 @@ public record DepartListComplaintResponseDto(
         List<DepartComplaintResponseDto> departs
 ) {
     public static DepartListComplaintResponseDto from(List<DepartComplaintResponseDto> departs) {
-        return new DepartListComplaintResponseDtodeparts();
+        return new DepartListComplaintResponseDto(departs);
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
@@ -33,4 +33,9 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     // 특정 부서로 분류되지 않은 전체 민원 개수 반환
     @Query("SELECT COUNT(c) FROM Complaint c WHERE c.file.id = :fileId AND c.depart IS NULL")
     Long countUnclassifiedComplaints(@Param("fileId") Long fileId);
+
+    // 여러 부서의 민원 확인을 취소하는 query
+    @Modifying
+    @Query("UPDATE Complaint c SET c.isChecked = false WHERE c.file.id = :fileId AND c.depart.id IN :departIds")
+    void uncheckComplaintsByFileIdAndDepartIds(@Param("fileId") Long fileId, @Param("departIds") List<Long> departIds);
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
@@ -17,4 +17,8 @@ public class DepartCheckService {
     public void checkDeparts(Long fileId, DepartListRequestDto requestDto){
         complaintRepository.checkComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
     }
+
+    public void uncheckDeparts(Long fileId, DepartListRequestDto requestDto) {
+        complaintRepository.uncheckComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Resolves: #22

## 📝 개요
특정 파일에 소속된 부서의 민원 확인 취소 기능 구현

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가

## ✅ 상세 내용
- PATCH /api/v1/files/{fileId}/departs/uncheck 엔드포인트 구현
- ComplaintRepository에 uncheckComplaintsByFileIdAndDepartIds 쿼리 추가
- DepartCheckService에 uncheckDeparts 메서드 추가
- FileController에 uncheckDeparts 엔드포인트 추가


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.