### PR TITLE
[Feat] 민원 단건 직접 입력 API 및 분류·배부 파이프라인 연동

### DIFF
--- a/ai-dispatcher/app/core/config.py
+++ b/ai-dispatcher/app/core/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     kafka_topic_embedding_trigger: str
     kafka_topic_classification_request: str
     kafka_topic_classification_response: str
+    kafka_topic_complaint_classification_request: str
+    kafka_topic_complaint_classification_response: str
     kafka_consumer_group_id: str
     
     embedding_model_name: str

--- a/ai-dispatcher/app/db/repository/embedding_repository.py
+++ b/ai-dispatcher/app/db/repository/embedding_repository.py
@@ -15,6 +15,10 @@ class EmbeddingRepository:
     def get_all_complaints_in_the_file(self, file_id: int) -> list[Complaint]:
         stmt = select(Complaint).where(Complaint.file_id == file_id)
         return list(self.session.scalars(stmt).all())
+
+    def get_complaint_by_id(self, complaint_id: int) -> Complaint | None:
+        stmt = select(Complaint).where(Complaint.id == complaint_id)
+        return self.session.scalars(stmt).first()
     
     def get_complaint_embedding(self, complaint_id) -> np.ndarray:
         stmt = select(ComplaintEmbedding).where(ComplaintEmbedding.complaint_id == complaint_id)

--- a/ai-dispatcher/app/messaging/consumer.py
+++ b/ai-dispatcher/app/messaging/consumer.py
@@ -9,11 +9,14 @@ from app.db.repository.embedding_repository import EmbeddingRepository
 from app.service.embedding_service import extract_embedding
 from app.service.depart_service import classify_depart
 from app.core.config import settings
-from app.messaging.producer import publish_classification_response
+from app.messaging.producer import publish_classification_response, publish_complaint_classification_response
 
 logger = logging.getLogger(__name__)
 
 _consumer: AIOKafkaConsumer | None = None
+
+def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
 
 async def start_consumer() -> None:
     """
@@ -26,6 +29,7 @@ async def start_consumer() -> None:
     _consumer = AIOKafkaConsumer(
         settings.kafka_topic_embedding_trigger,
         settings.kafka_topic_classification_request,
+        settings.kafka_topic_complaint_classification_request,
         bootstrap_servers=settings.kafka_bootstrap_servers,
         group_id=settings.kafka_consumer_group_id,
         auto_offset_reset="earliest",
@@ -82,9 +86,6 @@ async def _handle_message(message) -> None:
                 logger.error(f"에러 발생: {e}", exc_info=True)
                 
     elif(message.topic == settings.kafka_topic_classification_request):
-        def cosine_similarity(a: np.ndarray, b: np.ndarray) -> float:
-            return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
-        
         file_id = int(message.value)
         
         try:
@@ -101,7 +102,7 @@ async def _handle_message(message) -> None:
                     except Exception as e:
                         logger.error(f"민원 {complaint.id} 임베딩 중 에러 발생: {e}", exc_info=True)
                         complaint.status = "FAILED"
-                        complaint.failure_reason = str(e)
+                        complaint.failure_reason = str(e)[:100]
                 db.commit()
                 logger.info("complaint 임베딩 완료")
 
@@ -178,3 +179,73 @@ async def _handle_message(message) -> None:
                     await publish_classification_response(file_id)
             except Exception as inner_e:
                 logger.error(f"파일 실패 상태 저장 실패: {inner_e}")
+
+    elif message.topic == settings.kafka_topic_complaint_classification_request:
+        complaint_id = int(message.value)
+
+        try:
+            with get_db() as db:
+                repo = EmbeddingRepository(db)
+                complaint = repo.get_complaint_by_id(complaint_id)
+                process_code_types = repo.get_all_process_code_types()
+
+                try:
+                    embedding = extract_embedding(complaint.title + " " + complaint.content)
+                    repo.insert_complaint_embedding(complaint.id, embedding.tolist())
+                    db.commit()
+                except Exception as e:
+                    logger.error(f"민원 {complaint_id} 임베딩 중 에러: {e}", exc_info=True)
+                    complaint.status = "FAILED"
+                    complaint.failure_reason = str(e)[:100]
+                    db.commit()
+                    await publish_complaint_classification_response(complaint_id)
+                    return
+
+                complaint_embedding = repo.get_complaint_embedding(complaint.id)
+                best_code, best_similarity = None, -1.0
+                for pct in process_code_types:
+                    pct_embedding = repo.get_process_code_type_embedding(pct.code)
+                    if pct_embedding is None:
+                        continue
+                    similarity = cosine_similarity(complaint_embedding, pct_embedding)
+                    if similarity > best_similarity:
+                        best_similarity = similarity
+                        best_code = pct.code
+
+                if best_code is None:
+                    complaint.status = "FAILED"
+                    complaint.failure_reason = "no_embedding_for_any_process_code_type"
+                    db.commit()
+                    await publish_complaint_classification_response(complaint_id)
+                    return
+
+                complaint.code = best_code
+
+                try:
+                    depart_id, reason = await classify_depart(complaint, complaint_embedding, repo)
+                    if depart_id is not None:
+                        complaint.depart_id = depart_id
+                        complaint.status = "COMPLETED"
+                    else:
+                        complaint.status = "FAILED"
+                        complaint.failure_reason = reason
+                except BaseException as e:
+                    logger.error(f"민원 {complaint_id} 부서 분류 중 에러: {e}", exc_info=True)
+                    complaint.status = "FAILED"
+                    complaint.failure_reason = str(e)[:100]
+
+                db.commit()
+                await publish_complaint_classification_response(complaint_id)
+
+        except Exception as e:
+            logger.error(f"단건 민원 분류 중 에러: {e}", exc_info=True)
+            try:
+                with get_db() as db:
+                    repo = EmbeddingRepository(db)
+                    complaint = repo.get_complaint_by_id(complaint_id)
+                    complaint.status = "FAILED"
+                    complaint.failure_reason = str(e)[:100]
+                    db.commit()
+                    await publish_complaint_classification_response(complaint_id)
+            except Exception as inner_e:
+                logger.error(f"단건 민원 실패 상태 저장 실패: {inner_e}")

--- a/ai-dispatcher/app/messaging/producer.py
+++ b/ai-dispatcher/app/messaging/producer.py
@@ -39,7 +39,7 @@ async def publish_classification_response(file_id: int) -> None:
     """
     예측 완료 토픽 발행
     """
-    
+
     if _producer is None:
         logger.error("프로듀서가 초기화되지 않음")
         return
@@ -48,5 +48,17 @@ async def publish_classification_response(file_id: int) -> None:
         settings.kafka_topic_classification_response,
         value=str(file_id)
     )
-    
+
     logger.info("예측 결과 발행 완료")
+
+async def publish_complaint_classification_response(complaint_id: int) -> None:
+    if _producer is None:
+        logger.error("프로듀서가 초기화되지 않음")
+        return
+
+    await _producer.send_and_wait(
+        settings.kafka_topic_complaint_classification_response,
+        value=str(complaint_id)
+    )
+
+    logger.info("단건 민원 예측 결과 발행 완료")

--- a/ai-dispatcher/app/service/llm_service.py
+++ b/ai-dispatcher/app/service/llm_service.py
@@ -19,7 +19,7 @@ def _build_user_message(title: str, content: str, features: list[Feature]) -> st
 
 
 async def _call_llm(user_message: str) -> str:
-    client = AsyncOpenAI(base_url=settings.l그래 둘로lm_base_url, api_key=settings.llm_api_key, timeout=300.0)
+    client = AsyncOpenAI(base_url=settings.llm_base_url, api_key=settings.llm_api_key, timeout=300.0)
     response = await client.chat.completions.create(
         model=settings.llm_model,
         messages=[

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/ComplaintController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/ComplaintController.java
@@ -1,0 +1,30 @@
+package edu.dongguk.complaint.orchestrator.controller;
+
+import edu.dongguk.complaint.orchestrator.dto.request.ComplaintRequestDto;
+import edu.dongguk.complaint.orchestrator.service.command.ComplaintCreateService;
+import edu.dongguk.complaint.orchestrator.service.sse.SseEmitterService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("complaints")
+@RequiredArgsConstructor
+public class ComplaintController {
+
+    private final ComplaintCreateService complaintCreateService;
+    private final SseEmitterService sseEmitterService;
+
+    @PostMapping
+    public ResponseEntity<Long> createComplaint(@RequestBody @Valid ComplaintRequestDto complaintRequestDto) {
+        return ResponseEntity.ok(complaintCreateService.createComplaint(complaintRequestDto));
+    }
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe() {
+        return sseEmitterService.subscribe();
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/domain/complaint/Complaint.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/domain/complaint/Complaint.java
@@ -37,7 +37,7 @@ public class Complaint {
     private String failureReason;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "file_id", nullable = false)
+    @JoinColumn(name = "file_id", nullable = true)
     private File file;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/request/ComplaintRequestDto.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/dto/request/ComplaintRequestDto.java
@@ -1,0 +1,14 @@
+package edu.dongguk.complaint.orchestrator.dto.request;
+
+import jakarta.persistence.Lob;
+import jakarta.validation.constraints.NotBlank;
+
+public record ComplaintRequestDto(
+        @NotBlank
+        String title,
+
+        @Lob
+        @NotBlank
+        String content
+) {
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/event/ComplaintCreatedEvent.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/event/ComplaintCreatedEvent.java
@@ -1,0 +1,3 @@
+package edu.dongguk.complaint.orchestrator.event;
+
+public record ComplaintCreatedEvent(Long complaintId) {}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/event/FileDispatchCompleteEvent.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/event/FileDispatchCompleteEvent.java
@@ -1,0 +1,5 @@
+package edu.dongguk.complaint.orchestrator.event;
+
+import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
+
+public record FileDispatchCompleteEvent(Long fileId, FileStatus status) {}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/event/FileUploadedEvent.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/event/FileUploadedEvent.java
@@ -1,0 +1,3 @@
+package edu.dongguk.complaint.orchestrator.event;
+
+public record FileUploadedEvent(Long fileId) {}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/ComplaintCreateService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/ComplaintCreateService.java
@@ -1,0 +1,25 @@
+package edu.dongguk.complaint.orchestrator.service.command;
+
+import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
+import edu.dongguk.complaint.orchestrator.dto.request.ComplaintRequestDto;
+import edu.dongguk.complaint.orchestrator.event.ComplaintCreatedEvent;
+import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ComplaintCreateService {
+    private final ComplaintRepository complaintRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public Long createComplaint(ComplaintRequestDto complaintRequestDto) {
+        Complaint complaint = new Complaint(complaintRequestDto.title(), complaintRequestDto.content(), null);
+        complaintRepository.save(complaint);
+        eventPublisher.publishEvent(new ComplaintCreatedEvent(complaint.getId()));
+        return complaint.getId();
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/FileUploadService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/FileUploadService.java
@@ -3,13 +3,13 @@ package edu.dongguk.complaint.orchestrator.service.command;
 import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
 import edu.dongguk.complaint.orchestrator.domain.file.File;
 import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
+import edu.dongguk.complaint.orchestrator.event.FileUploadedEvent;
 import edu.dongguk.complaint.orchestrator.global.util.ComplaintData;
 import edu.dongguk.complaint.orchestrator.global.util.ExcelParser;
 import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
 import edu.dongguk.complaint.orchestrator.repository.FileRepository;
-import edu.dongguk.complaint.orchestrator.service.kafka.FileKafkaProducer;
-import edu.dongguk.complaint.orchestrator.service.sse.SseEmitterService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,8 +24,7 @@ public class FileUploadService {
 
     private final FileRepository fileRepository;
     private final ComplaintRepository complaintRepository;
-    private final FileKafkaProducer kafkaProducer;
-    private final SseEmitterService sseEmitterService;
+    private final ApplicationEventPublisher eventPublisher;
     private final ExcelParser excelParser;
 
     public Long uploadFile(MultipartFile multipartFile) throws IOException {
@@ -43,9 +42,7 @@ public class FileUploadService {
         file.updateRowCount(complaints.size());
         fileRepository.save(file);
 
-        sseEmitterService.notify(file.getId(), FileStatus.PENDING);
-
-        kafkaProducer.sendAnalysisRequest(file.getId());
+        eventPublisher.publishEvent(new FileUploadedEvent(file.getId()));
 
         return file.getId();
     }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/event/ComplaintEventListener.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/event/ComplaintEventListener.java
@@ -1,0 +1,20 @@
+package edu.dongguk.complaint.orchestrator.service.event;
+
+import edu.dongguk.complaint.orchestrator.event.ComplaintCreatedEvent;
+import edu.dongguk.complaint.orchestrator.service.kafka.ComplaintKafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ComplaintEventListener {
+
+    private final ComplaintKafkaProducer complaintKafkaProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleComplaintCreated(ComplaintCreatedEvent event) {
+        complaintKafkaProducer.sendDispatchRequest(event.complaintId());
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/event/FileEventListener.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/event/FileEventListener.java
@@ -1,0 +1,30 @@
+package edu.dongguk.complaint.orchestrator.service.event;
+
+import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
+import edu.dongguk.complaint.orchestrator.event.FileDispatchCompleteEvent;
+import edu.dongguk.complaint.orchestrator.event.FileUploadedEvent;
+import edu.dongguk.complaint.orchestrator.service.kafka.FileKafkaProducer;
+import edu.dongguk.complaint.orchestrator.service.sse.SseEmitterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class FileEventListener {
+
+    private final FileKafkaProducer fileKafkaProducer;
+    private final SseEmitterService sseEmitterService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFileUploaded(FileUploadedEvent event) {
+        sseEmitterService.notify(event.fileId(), FileStatus.PENDING);
+        fileKafkaProducer.sendAnalysisRequest(event.fileId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleFileDispatchComplete(FileDispatchCompleteEvent event) {
+        sseEmitterService.notify(event.fileId(), event.status());
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/kafka/ComplaintKafkaConsumer.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/kafka/ComplaintKafkaConsumer.java
@@ -1,0 +1,33 @@
+package edu.dongguk.complaint.orchestrator.service.kafka;
+
+import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
+import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
+import edu.dongguk.complaint.orchestrator.service.sse.SseEmitterService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Component
+@RequiredArgsConstructor
+public class ComplaintKafkaConsumer {
+
+    private final ComplaintRepository complaintRepository;
+    private final SseEmitterService sseEmitterService;
+
+    @KafkaListener(topics = "complaint-dispatch-complete", groupId = "complaint-group")
+    @Transactional
+    public void consume(String complaintId) {
+        Complaint complaint = complaintRepository.findById(Long.parseLong(complaintId))
+                .orElseThrow(NoSuchElementException::new);
+
+        sseEmitterService.notifyComplaintResult(
+                complaint.getId(),
+                complaint.getDepart() != null ? complaint.getDepart().getId() : null,
+                complaint.getProcessCodeType() != null ? complaint.getProcessCodeType().getCode() : null,
+                complaint.getFailureReason()
+        );
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/kafka/ComplaintKafkaProducer.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/kafka/ComplaintKafkaProducer.java
@@ -1,0 +1,16 @@
+package edu.dongguk.complaint.orchestrator.service.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ComplaintKafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    public void sendDispatchRequest(Long complaintId) {
+        kafkaTemplate.send("complaint-dispatch", complaintId.toString());
+    }
+}

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/kafka/FileKafkaConsumer.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/kafka/FileKafkaConsumer.java
@@ -4,10 +4,11 @@ import edu.dongguk.complaint.orchestrator.domain.complaint.Complaint;
 import edu.dongguk.complaint.orchestrator.domain.complaint.ComplaintStatus;
 import edu.dongguk.complaint.orchestrator.domain.file.File;
 import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
+import edu.dongguk.complaint.orchestrator.event.FileDispatchCompleteEvent;
 import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
 import edu.dongguk.complaint.orchestrator.repository.FileRepository;
-import edu.dongguk.complaint.orchestrator.service.sse.SseEmitterService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +22,7 @@ public class FileKafkaConsumer {
 
     private final FileRepository fileRepository;
     private final ComplaintRepository complaintRepository;
-    private final SseEmitterService sseEmitterService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @KafkaListener(topics = "file-dispatch-complete", groupId = "complaint-group")
     @Transactional
@@ -41,6 +42,6 @@ public class FileKafkaConsumer {
         else
             newStatus = FileStatus.ERROR;
 
-        sseEmitterService.notify(id, newStatus);
+        eventPublisher.publishEvent(new FileDispatchCompleteEvent(id, newStatus));
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/sse/SseEmitterService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/sse/SseEmitterService.java
@@ -1,10 +1,12 @@
 package edu.dongguk.complaint.orchestrator.service.sse;
 
+import edu.dongguk.complaint.orchestrator.domain.complaint.ComplaintStatus;
 import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -30,6 +32,21 @@ public class SseEmitterService {
         emitters.forEach((id, emitter) -> {
             try {
                 emitter.send(SseEmitter.event().name("file-status").data(data));
+            } catch (IOException e) {
+                emitters.remove(id);
+            }
+        });
+    }
+
+    public void notifyComplaintResult(Long complaintId, Long departId, Integer code, String failureReason) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("complaintId", complaintId);
+        data.put("departId", departId);
+        data.put("code", code);
+        data.put("failureReason", failureReason);
+        emitters.forEach((id, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event().name("complaint-status").data(data));
             } catch (IOException e) {
                 emitters.remove(id);
             }

--- a/complaint-orchestrator/src/main/resources/db/migration/V17__alter_complaint_file_id_nullable.sql
+++ b/complaint-orchestrator/src/main/resources/db/migration/V17__alter_complaint_file_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE complaint ALTER COLUMN file_id DROP NOT NULL;


### PR DESCRIPTION
## 🔗 관련 이슈
-    Resolves: #29
  
## 📝 개요
- 파일 업로드 없이 민원을 단건으로 직접 입력하고, 기존 분류 및 배부 파이프라인과 연동하여 결과를 SSE로 실시간 전달하는 REST API 구현
- 서울교통공사 RPA 연동 시나리오처럼 파일 없이 민원 내용만 전달하는 케이스를 지원

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용

**Spring 서버**
- DB 마이그레이션 (`V17`): `complaint.file_id NOT NULL -> NULL 허용` (FK 유지), 파일 업로드 민원(`file_id ≥ 1`)과 단건 민원(`file_id = NULL`) 구분
- `POST /api/complaints`: `ComplaintController`, `ComplaintRequestDto`, `ComplaintCreateService` 신규 구현
- `ComplaintKafkaProducer`: 단건 민원 분류 요청 토픽 발행
- `ComplaintKafkaConsumer`: 배부 완료 결과 수신 후 `SseEmitterService`로 이벤트 푸시
- `@TransactionalEventListener` 리팩토링: Kafka, SSE 발행 시점을 트랜잭션 커밋 이후로 이동하여 발행 전 롤백 케이스 방지
    - `ComplaintCreatedEvent`, `FileUploadedEvent`, `FileDispatchCompleteEvent` 이벤트 클래스 추가
    - `ComplaintEventListener`, `FileEventListener` 이벤트 리스너로 분리

**AI Dispatcher**
- `consumer.py`: topic 이름으로 유무로 단건과 파일 업로드 민원을 분기하여 단건 분류 파이프라인 추가
- `producer.py`: 단건 민원 배부 완료 결과 Kafka 메시지 발행 구현

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.