### PR TITLE
[CI/CD] ai-dispatcher HuggingFace 모델 캐시 bind mount 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,7 +142,9 @@ jobs:
              (.containerDefinitions[0].environment[] | select(.name == "EMBEDDING_MODEL_NAME")).value = $emb_model |
              (.containerDefinitions[0].environment[] | select(.name == "LLM_MODEL")).value = $llm_model |
              (.containerDefinitions[0].environment[] | select(.name == "LLM_API_KEY")).value = $llm_key |
-             (.containerDefinitions[0].environment[] | select(.name == "LLM_BASE_URL")).value = $llm_url')
+             (.containerDefinitions[0].environment[] | select(.name == "LLM_BASE_URL")).value = $llm_url |
+             .volumes = [{"name": "huggingface-cache", "host": {"sourcePath": "/opt/huggingface-cache"}}] |
+             .containerDefinitions[0].mountPoints = [{"containerPath": "/root/.cache/huggingface", "sourceVolume": "huggingface-cache", "readOnly": false}]')
 
           NEW_ARN=$(aws ecs register-task-definition \
             --cli-input-json "$NEW_TASK_DEF" \


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## 📝 개요
- EC2 호스트 경로를 컨테이너에 마운트해서 모델을 한 번만 다운받고 재사용

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [x] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- EC2 /opt/huggingface-cache와 컨테이너 /root/.cache/huggingface 마운트
- 첫 배포: KURE-v1 모델 EC2 호스트에 다운로드 (2.3GB, 한 번만)
- 이후 배포: 캐시 재사용, 다운로드 없음


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.