### PR TITLE
[Fix] SSE timeout 및 isChecked 항상 true 반환 버그 수정

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
@@ -56,7 +56,7 @@ public class FileQueryService {
                 .map(row -> {
                     Depart depart = (Depart) row[0];
                     Long count = (Long) row[1];
-                    boolean isChecked = !uncheckedDeparts.contains(depart.getId());
+                    boolean isChecked = uncheckedDeparts.stream().noneMatch(d -> d.getId().equals(depart.getId()));
                     return DepartComplaintResponseDto.from(depart, count, isChecked);
                 })
                 .toList();

--- a/nginx/nginx-ecs.conf
+++ b/nginx/nginx-ecs.conf
@@ -15,7 +15,22 @@ http {
     server {
         listen 80;
 
-        location /sse {
+        location /complaints/subscribe {
+            proxy_pass http://spring;
+            proxy_http_version 1.1;
+
+            proxy_set_header Connection '';
+            chunked_transfer_encoding on;
+
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /files/subscribe {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -15,7 +15,22 @@ http {
     server {
         listen 80;
 
-        location /sse {
+        location /complaints/subscribe {
+            proxy_pass http://spring;
+            proxy_http_version 1.1;
+
+            proxy_set_header Connection '';
+            chunked_transfer_encoding on;
+
+            proxy_buffering off;
+            proxy_read_timeout 3600s;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /files/subscribe {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## 📝 개요
- SSE 연결이 60초 후 끊기는 문제와 부서 확인 여부(`isChecked`)가 항상 `true`로 반환되는 버그 2건을 수정

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
  - **SSE nginx location 경로 수정**: `/sse` location이 실제 엔드포인트(`/complaints/subscribe`, `/files/subscribe`)와 불일치하여 SSE 연결이 `location /`의 60s timeout에 걸려 끊기던 문제 수정. 두 엔드포인트를 별도 location 블록으로 분리하고 `proxy_read_timeout 3600s` 적용 (`nginx.conf`, `nginx-ecs.conf` 동일 적용)
  - **isChecked 항상 true 반환 버그 수정**: `List<Depart>.contains(Long)` 타입 불일치로 `contains()`가 항상 `false`를 반환해 `isChecked`가 항상 `true`로 설정되던 문제를 `stream().noneMatch(d -> d.getId().equals(...))`로 수정 (`FileQueryService.java`)


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.