### PR TITLE
[Chore] nginx API location에 /api/v1 prefix 추가

### DIFF
--- a/nginx/nginx-ecs.conf
+++ b/nginx/nginx-ecs.conf
@@ -15,7 +15,7 @@ http {
     server {
         listen 80;
 
-        location /complaints/subscribe {
+        location /api/v1/complaints/subscribe {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 
@@ -30,7 +30,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location /files/subscribe {
+        location /api/v1/files/subscribe {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 
@@ -45,7 +45,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location / {
+        location /api/v1/ {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -15,7 +15,7 @@ http {
     server {
         listen 80;
 
-        location /complaints/subscribe {
+        location /api/v1/complaints/subscribe {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 
@@ -30,7 +30,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location /files/subscribe {
+        location /api/v1/files/subscribe {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 
@@ -45,7 +45,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
-        location / {
+        location /api/v1/ {
             proxy_pass http://spring;
             proxy_http_version 1.1;
 


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## 📝 개요
- 클라이언트 요청 경로에 `/api/v1` prefix를 적용하기 위해 nginx location 블록 경로를 수정

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [x] 기타 (설명 필요)

## ✅ 상세 내용
- `nginx.conf`, `nginx-ecs.conf`의 모든 location 경로에 `/api/v1` prefix 추가


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.