### PR TITLE
[fix] 파일 목록에서 전체 부서 수로 표시되는 문제 수정

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
@@ -38,4 +38,8 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     @Modifying
     @Query("UPDATE Complaint c SET c.isChecked = false WHERE c.file.id = :fileId AND c.depart.id IN :departIds")
     void uncheckComplaintsByFileIdAndDepartIds(@Param("fileId") Long fileId, @Param("departIds") List<Long> departIds);
+
+    // 특정 파일의 민원이 배부된 부서의 총 개수를 반환하는 query
+    @Query("SELECT COUNT(DISTINCT c.depart.id) FROM Complaint c WHERE c.file.id = :fileId AND c.depart IS NOT NULL")
+    long countDistinctDepartsByFileId(@Param("fileId") Long fileId);
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
@@ -1,11 +1,16 @@
 package edu.dongguk.complaint.orchestrator.service.command;
 
+import edu.dongguk.complaint.orchestrator.domain.file.File;
+import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
 import edu.dongguk.complaint.orchestrator.dto.request.DepartListRequestDto;
 import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
+import edu.dongguk.complaint.orchestrator.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
 
 @Service
 @Transactional
@@ -13,12 +18,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class DepartCheckService {
 
     private final ComplaintRepository complaintRepository;
+    private final FileRepository fileRepository;
 
     public void checkDeparts(Long fileId, DepartListRequestDto requestDto){
         complaintRepository.checkComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
+
+        // 모든 부서 체크 완료 시 file status를 COMPLETE로 변경
+        long totalDeparts = complaintRepository.countDistinctDepartsByFileId(fileId);
+        long checkedDeparts = complaintRepository.countCheckedDepartsByFileId(fileId);
+
+        if (totalDeparts > 0 && totalDeparts == checkedDeparts) {
+            File file = fileRepository.findById(fileId)
+                    .orElseThrow(NoSuchElementException::new);
+            file.updateStatus(FileStatus.COMPLETED);
+        }
     }
 
     public void uncheckDeparts(Long fileId, DepartListRequestDto requestDto) {
         complaintRepository.uncheckComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
+
+        // 부서 체크 해제 시 file status를 PENDING로 변경
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(NoSuchElementException::new);
+        if (file.getStatus() == FileStatus.COMPLETED) {
+            file.updateStatus(FileStatus.PENDING);
+        }
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
@@ -22,14 +22,13 @@ import java.util.ArrayList;
 public class FileQueryService {
     private final FileRepository fileRepository;
     private final ComplaintRepository complaintRepository;
-    private final DepartRepository departRepository;
 
     public FileListResponseDto getfiles() {
         List<File> files = fileRepository.findAll();
-        long totalDeparts = departRepository.count();
 
         List<FileResponseDto> fileResponseDtoList = files.stream()
                 .map(file -> {
+                    long totalDeparts = complaintRepository.countDistinctDepartsByFileId(file.getId());
                     long checkedDeparts = complaintRepository.countCheckedDepartsByFileId(file.getId());
                     String checkedDepartCount = checkedDeparts + "/" + totalDeparts;
                     return FileResponseDto.from(file, checkedDepartCount);


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 해결하는 이슈 번호를 명시하세요. Resolves: #43 

## 📝 개요
- 파일 목록 조회 시 부서 체크 현황이 전체 부서 수(383개)를 분모로 표시되는 문제를 수정
- 해당 파일의 민원이 실제로 배부된 부서 수를 분모로 표시하도록 변경하고, 모든 부서 확인 완료 시 파일 상태가 배부완료(COMPLETED)로 변경되는 기능을 추가

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- ComplaintRepository에 해당 파일에 민원이 배부된 부서 수를 조회하는 쿼리(countDistinctDepartsByFileId) 추가
- FileQueryService.getfiles()에서 분모를 전체 부서 수(departRepository.count())에서 해당 파일의 배부된 부서 수(countDistinctDepartsByFileId)로 변경
- DepartCheckService에 FileRepository 의존성 추가
- DepartCheckService.checkDeparts()에서 모든 부서 확인 완료 시 file status를 COMPLETED로 변경하는 로직 추가
- DepartCheckService.uncheckDeparts()에서 체크 해제 시 file status가 COMPLETED인 경우 PENDING으로 복귀하는 로직 추가


## 📌 체크리스트
- [ ] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.