### PR TITLE
[Security] nginx HTTPS 설정 및 Let's Encrypt 인증서 발급 자동화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,14 +158,27 @@ jobs:
 
       - name: Deploy nginx
         run: |
+          SSL_CERT_ARN=$(aws secretsmanager describe-secret \
+            --secret-id metro/nginx/ssl-cert \
+            --query ARN --output text)
+          SSL_KEY_ARN=$(aws secretsmanager describe-secret \
+            --secret-id metro/nginx/ssl-key \
+            --query ARN --output text)
+
           TASK_DEF=$(aws ecs describe-task-definition \
             --task-definition metro-nginx \
             --query taskDefinition --output json)
 
           NEW_TASK_DEF=$(echo $TASK_DEF | jq \
             --arg image "$ECR_REGISTRY/dgu-metro/nginx:${{ github.sha }}" \
+            --arg ssl_cert_arn "$SSL_CERT_ARN" \
+            --arg ssl_key_arn "$SSL_KEY_ARN" \
             'del(.taskDefinitionArn,.revision,.status,.requiresAttributes,.placementConstraints,.compatibilities,.registeredAt,.registeredBy) |
-             .containerDefinitions[0].image = $image')
+             .containerDefinitions[0].image = $image |
+             .containerDefinitions[0].secrets = [
+               {"name": "SSL_CERT", "valueFrom": $ssl_cert_arn},
+               {"name": "SSL_KEY", "valueFrom": $ssl_key_arn}
+             ]')
 
           NEW_ARN=$(aws ecs register-task-definition \
             --cli-input-json "$NEW_TASK_DEF" \

--- a/.github/workflows/issue-cert.yml
+++ b/.github/workflows/issue-cert.yml
@@ -1,0 +1,52 @@
+name: Issue SSL Certificate
+
+on:
+  workflow_dispatch:
+
+env:
+  AWS_REGION: ap-northeast-2
+
+jobs:
+  issue-cert:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Install certbot
+        run: pip install certbot certbot-dns-route53
+
+      - name: Issue certificate
+        run: |
+          certbot certonly \
+            --dns-route53 \
+            --domain dguseoulmetro.xyz \
+            --email ${{ secrets.CERTBOT_EMAIL }} \
+            --agree-tos \
+            --non-interactive \
+            --no-eff-email
+
+      - name: Store certs in Secrets Manager
+        run: |
+          CERT=$(cat /etc/letsencrypt/live/dguseoulmetro.xyz/fullchain.pem)
+          KEY=$(cat /etc/letsencrypt/live/dguseoulmetro.xyz/privkey.pem)
+
+          aws secretsmanager create-secret \
+            --name metro/nginx/ssl-cert \
+            --secret-string "$CERT" 2>/dev/null || \
+          aws secretsmanager put-secret-value \
+            --secret-id metro/nginx/ssl-cert \
+            --secret-string "$CERT"
+
+          aws secretsmanager create-secret \
+            --name metro/nginx/ssl-key \
+            --secret-string "$KEY" 2>/dev/null || \
+          aws secretsmanager put-secret-value \
+            --secret-id metro/nginx/ssl-key \
+            --secret-string "$KEY"
+
+          echo "Cert stored successfully"

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
@@ -38,4 +38,8 @@ public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     @Modifying
     @Query("UPDATE Complaint c SET c.isChecked = false WHERE c.file.id = :fileId AND c.depart.id IN :departIds")
     void uncheckComplaintsByFileIdAndDepartIds(@Param("fileId") Long fileId, @Param("departIds") List<Long> departIds);
+
+    // 특정 파일의 민원이 배부된 부서의 총 개수를 반환하는 query
+    @Query("SELECT COUNT(DISTINCT c.depart.id) FROM Complaint c WHERE c.file.id = :fileId AND c.depart IS NOT NULL")
+    long countDistinctDepartsByFileId(@Param("fileId") Long fileId);
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
@@ -1,11 +1,16 @@
 package edu.dongguk.complaint.orchestrator.service.command;
 
+import edu.dongguk.complaint.orchestrator.domain.file.File;
+import edu.dongguk.complaint.orchestrator.domain.file.FileStatus;
 import edu.dongguk.complaint.orchestrator.dto.request.DepartListRequestDto;
 import edu.dongguk.complaint.orchestrator.repository.ComplaintRepository;
+import edu.dongguk.complaint.orchestrator.repository.FileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
 
 @Service
 @Transactional
@@ -13,12 +18,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class DepartCheckService {
 
     private final ComplaintRepository complaintRepository;
+    private final FileRepository fileRepository;
 
     public void checkDeparts(Long fileId, DepartListRequestDto requestDto){
         complaintRepository.checkComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
+
+        // 모든 부서 체크 완료 시 file status를 COMPLETE로 변경
+        long totalDeparts = complaintRepository.countDistinctDepartsByFileId(fileId);
+        long checkedDeparts = complaintRepository.countCheckedDepartsByFileId(fileId);
+
+        if (totalDeparts > 0 && totalDeparts == checkedDeparts) {
+            File file = fileRepository.findById(fileId)
+                    .orElseThrow(NoSuchElementException::new);
+            file.updateStatus(FileStatus.COMPLETED);
+        }
     }
 
     public void uncheckDeparts(Long fileId, DepartListRequestDto requestDto) {
         complaintRepository.uncheckComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
+
+        // 부서 체크 해제 시 file status를 PENDING로 변경
+        File file = fileRepository.findById(fileId)
+                .orElseThrow(NoSuchElementException::new);
+        if (file.getStatus() == FileStatus.COMPLETED) {
+            file.updateStatus(FileStatus.PENDING);
+        }
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/FileQueryService.java
@@ -22,14 +22,13 @@ import java.util.ArrayList;
 public class FileQueryService {
     private final FileRepository fileRepository;
     private final ComplaintRepository complaintRepository;
-    private final DepartRepository departRepository;
 
     public FileListResponseDto getfiles() {
         List<File> files = fileRepository.findAll();
-        long totalDeparts = departRepository.count();
 
         List<FileResponseDto> fileResponseDtoList = files.stream()
                 .map(file -> {
+                    long totalDeparts = complaintRepository.countDistinctDepartsByFileId(file.getId());
                     long checkedDeparts = complaintRepository.countCheckedDepartsByFileId(file.getId());
                     String checkedDepartCount = checkedDeparts + "/" + totalDeparts;
                     return FileResponseDto.from(file, checkedDepartCount);

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,2 +1,5 @@
 FROM nginx:alpine
 COPY nginx-ecs.conf /etc/nginx/nginx.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+mkdir -p /etc/nginx/ssl
+printf '%s' "$SSL_CERT" > /etc/nginx/ssl/fullchain.pem
+printf '%s' "$SSL_KEY"  > /etc/nginx/ssl/privkey.pem
+exec nginx -g 'daemon off;'

--- a/nginx/nginx-ecs.conf
+++ b/nginx/nginx-ecs.conf
@@ -14,6 +14,18 @@ http {
 
     server {
         listen 80;
+        server_name dguseoulmetro.xyz;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name dguseoulmetro.xyz;
+
+        ssl_certificate     /etc/nginx/ssl/fullchain.pem;
+        ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
 
         location /api/v1/complaints/subscribe {
             proxy_pass http://spring;
@@ -28,6 +40,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
         }
 
         location /api/v1/files/subscribe {
@@ -43,6 +56,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
         }
 
         location /api/v1/ {
@@ -52,6 +66,7 @@ http {
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
 
             proxy_connect_timeout 10s;
             proxy_read_timeout 60s;


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## 📝 개요
- 파일 목록에서 전체 부서 수로 잘못 표시되는 버그 수정
- 서비스 HTTPS 적용을 위해 nginx SSL 설정 및 Let's Encrypt 인증서 발급 자동화

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [x] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [x] 기타 (보안 - HTTPS 설정)

## ✅ 상세 내용
- 파일 목록 조회 시 전체 부서 수 대신 해당 민원의 부서 수를 반환하도록 수정
- nginx-ecs.conf: HTTP(80) -> HTTPS(301 리다이렉트), HTTPS(443) 서버 블록 추가 (TLSv1.2/1.3)
- nginx/entrypoint.sh: ECS 주입 환경변수(SSL_CERT, SSL_KEY)를 인증서 파일로 변환 후 nginx 시작
- issue-cert.yml: certbot-dns-route53으로 Let's Encrypt 인증서 발급 및 Secrets Manager 저장 (수동 1회 실행)
- deploy.yml: nginx 태스크 정의에 Secrets Manager SSL 인증서 ARN 자동 주입

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.