### PR TITLE
:art: Refactor: DepartCheckService에서 파일 상태 변경 로직 제거

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
@@ -22,26 +22,9 @@ public class DepartCheckService {
 
     public void checkDeparts(Long fileId, DepartListRequestDto requestDto){
         complaintRepository.checkComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
-
-        // 모든 부서 체크 완료 시 file status를 COMPLETE로 변경
-        long totalDeparts = complaintRepository.countDistinctDepartsByFileId(fileId);
-        long checkedDeparts = complaintRepository.countCheckedDepartsByFileId(fileId);
-
-        if (totalDeparts > 0 && totalDeparts == checkedDeparts) {
-            File file = fileRepository.findById(fileId)
-                    .orElseThrow(NoSuchElementException::new);
-            file.updateStatus(FileStatus.COMPLETED);
-        }
     }
 
     public void uncheckDeparts(Long fileId, DepartListRequestDto requestDto) {
         complaintRepository.uncheckComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
-
-        // 부서 체크 해제 시 file status를 PENDING로 변경
-        File file = fileRepository.findById(fileId)
-                .orElseThrow(NoSuchElementException::new);
-        if (file.getStatus() == FileStatus.COMPLETED) {
-            file.updateStatus(FileStatus.PENDING);
-        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Resolves: #48

## 📝 개요
- 파일 상태는 AI 분류 완료 시점에만 변경되어야 하는데, 부서 체크/언체크 시에도 FileStatus가 변경되는 문제가 있어 로직을 단순화

## 🧩 PR 유형 (중복 선택 가능)
- [x] 리팩토링 (기능 변경 없음)

## ✅ 상세 내용
- checkDeparts, uncheckDeparts에서 FileStatus 업데이트 로직 제거
- 파일 상태는 AI 분류 완료 시점에만 변경되도록 단순화

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.