### PR TITLE
[Refactor] DepartCheckService 파일 상태 변경 로직 제거

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/command/DepartCheckService.java
@@ -22,26 +22,9 @@ public class DepartCheckService {
 
     public void checkDeparts(Long fileId, DepartListRequestDto requestDto){
         complaintRepository.checkComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
-
-        // 모든 부서 체크 완료 시 file status를 COMPLETE로 변경
-        long totalDeparts = complaintRepository.countDistinctDepartsByFileId(fileId);
-        long checkedDeparts = complaintRepository.countCheckedDepartsByFileId(fileId);
-
-        if (totalDeparts > 0 && totalDeparts == checkedDeparts) {
-            File file = fileRepository.findById(fileId)
-                    .orElseThrow(NoSuchElementException::new);
-            file.updateStatus(FileStatus.COMPLETED);
-        }
     }
 
     public void uncheckDeparts(Long fileId, DepartListRequestDto requestDto) {
         complaintRepository.uncheckComplaintsByFileIdAndDepartIds(fileId, requestDto.departIds());
-
-        // 부서 체크 해제 시 file status를 PENDING로 변경
-        File file = fileRepository.findById(fileId)
-                .orElseThrow(NoSuchElementException::new);
-        if (file.getStatus() == FileStatus.COMPLETED) {
-            file.updateStatus(FileStatus.PENDING);
-        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## 📝 개요
- `DepartCheckService`의 `checkDeparts` / `uncheckDeparts`에서 `FileStatus` 변경 로직을 제거
- 파일 상태(`COMPLETED`, `PENDING`) 전이는 AI 분류 완료 시점에서만 일어나야 하는데, 개념 혼동으로 부서 체크/해제 시에도 상태가 변경되던 문제 수정

## 🧩 PR 유형 (중복 선택 가능)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- `checkDeparts`: 모든 부서 체크 완료 시 `FileStatus.COMPLETED`로 변경하던 로직 제거
- `uncheckDeparts`: 부서 체크 해제 시 `FileStatus.PENDING`으로 되돌리던 로직 제거

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.