### PR TITLE
:bug: Fix: 부서별 민원 조회 시 다른 파일 및 단건 민원이 포함되는 문제 수정

### DIFF
--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/controller/DepartController.java
@@ -17,9 +17,10 @@ public class DepartController {
     @GetMapping("/{departId}")
     public ResponseEntity<ComplaintListResponseDto> getComplaints(
             @PathVariable Long departId,
+            @RequestParam Long fileId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int  size){
         Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok(complaintQueryService.getComplaints(departId,  pageable));
+        return ResponseEntity.ok(complaintQueryService.getComplaints(fileId, departId,  pageable));
     }
 }

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/repository/ComplaintRepository.java
@@ -13,7 +13,9 @@ import java.util.List;
 
 public interface ComplaintRepository extends JpaRepository<Complaint, Long> {
     List<Complaint> findAllByFileId(Long fileId);
-    Slice<Complaint> findByDepartId(Long departId, Pageable pageable);
+
+    // 쿼리메서드로 구현, 단건 민원(file_id = null)은 자동으로 제외됨
+    Slice<Complaint> findByFileIdAndDepartId(Long fileId, Long departId, Pageable pageable);
 
     @Query("SELECT COUNT(DISTINCT c.depart.id) FROM Complaint c WHERE c.file.id = :fileId AND c.isChecked = true")
     long countCheckedDepartsByFileId(@Param("fileId") Long fileId);

--- a/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/ComplaintQueryService.java
+++ b/complaint-orchestrator/src/main/java/edu/dongguk/complaint/orchestrator/service/query/ComplaintQueryService.java
@@ -19,9 +19,9 @@ import java.util.List;
 public class ComplaintQueryService {
     private final ComplaintRepository complaintRepository;
 
-    public ComplaintListResponseDto getComplaints(Long departId, Pageable pageable) {
+    public ComplaintListResponseDto getComplaints(Long fileId, Long departId, Pageable pageable) {
 
-        Slice<Complaint> slice = complaintRepository.findByDepartId(departId, pageable);
+        Slice<Complaint> slice = complaintRepository.findByFileIdAndDepartId(fileId, departId, pageable);
 
         List<ComplaintResponseDto> complaints = slice
                 .stream()


### PR DESCRIPTION
## 🔗 관련 이슈
Resolves: #52

## 📝 개요
- 부서별 민원 조회 시 departId만으로 조회하여 다른 파일 및 단건 민원(file_id=null)이 함께 조회되던 문제를 수정

## 🧩 PR 유형 (중복 선택 가능)
- [x] 버그 수정

## ✅ 상세 내용
- findByDepartId를 findByFileIdAndDepartId로 변경하여 특정 파일 민원만 조회
- DepartController에 fileId RequestParam 추가
- ComplaintQueryService에 fileId 파라미터 전달

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다.
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.